### PR TITLE
Add scripts to build statically-linked htslib

### DIFF
--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -1,0 +1,68 @@
+name: Build a statically linked htslib.dll under msys2
+on:
+  push:
+    paths:
+      - '.github/workflows/msys2-htslib-build.yml'
+      - 'patches/**'
+      - 'scripts/**'
+  workflow_dispatch:
+env:
+  PACKAGE_VERSION: 1.15.1
+  LIBHTS_SOVERSION: 3
+  RELEASE_VERSION: 0 # equivalent to conda build number
+jobs:
+  build:
+    name: build
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ci
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+      - name: System information
+        run: |
+          echo $MSYSTEM
+          uname -a
+          echo $PATH
+      - name: Install dependencies with pacman
+        run: bash ci/scripts/install-dependencies.sh
+      - name: Download and extract source htslib tarball
+        run: bash ci/scripts/download-htslib.sh
+      - name: Build
+        run: bash ci/scripts/build-htslib.sh ci/patches
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Check linking
+        shell: powershell
+        run: |
+          dumpbin /imports hts-${env:LIBHTS_SOVERSION}.dll | findstr /i dll
+      - name: Bundle
+        run: bash ci/scripts/bundle-htslib.sh
+      - name: Upload release tarball as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: m2w64-htslib-${{ env.PACKAGE_VERSION }}-${{ env.RELEASE_VERSION }}.tar.gz
+          path: m2w64-htslib-${{ env.PACKAGE_VERSION }}-${{ env.RELEASE_VERSION }}.tar.gz
+          retention-days: 14
+  release:
+    name: release
+    needs: build
+    if: github.repository == 'TileDB-Inc/m2w64-htslib-build' &&  github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download release tarball artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: m2w64-htslib-${{ env.PACKAGE_VERSION }}-${{ env.RELEASE_VERSION }}.tar.gz
+      - run: ls -lhR
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/release.sh

--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -5,6 +5,11 @@ on:
       - '.github/workflows/msys2-htslib-build.yml'
       - 'patches/**'
       - 'scripts/**'
+  pull_request:
+    paths:
+      - '.github/workflows/msys2-htslib-build.yml'
+      - 'patches/**'
+      - 'scripts/**'
   workflow_dispatch:
 env:
   PACKAGE_VERSION: 1.15.1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # m2w64-htslib-build
+
+The workflow [msys2-htslib-build.yml][] builds a statically linked htslib.dll
+under msys2. See the [releases][] to download the tarball. To build a different
+version of htslib, update the env var `PACKAGE_VERSION`. To build an updated
+release of an existing version, update the env var `RELEASE_VERSION`. Also, make
+sure that `RELEASE_VERSION` is reset to 0 when bumping the version.
+
+[msys2-htslib-build.yml]: https://github.com/TileDB-Inc/m2w64-htslib-build/blob/main/.github/workflows/msys2-htslib-build.yml
+[releases]: https://github.com/TileDB-Inc/m2w64-htslib-build/releases
+
+The release tarball is subsequently consumed by
+[TileDB-Inc/m2w64-htslib-feedstock][], which repackages the pre-built files into
+a conda binary. The end goal is for [TileDB-Inc/tiledb-vcf-feedstock][] to
+create a conda binary for Windows that builds [TileDB-Inc/TileDB-VCF][] with
+MSVC and links to the htslib that was built under msys2 (since the upstream
+maintainers of htslib only officially supporting building htslib for Windows
+under msys2).
+
+[TileDB-Inc/m2w64-htslib-feedstock]: https://github.com/TileDB-Inc/m2w64-htslib-feedstock
+[TileDB-Inc/tiledb-vcf-feedstock]: https://github.com/TileDB-Inc/tiledb-vcf-feedstock
+[TileDB-Inc/TileDB-VCF]: https://github.com/TileDB-Inc/TileDB-VCF

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # m2w64-htslib-build
 
-The workflow [msys2-htslib-build.yml][] builds a statically linked htslib.dll
+The workflow [msys2-htslib-build.yml][] builds a statically linked[^explanation] htslib.dll
 under msys2. See the [releases][] to download the tarball. To build a different
 version of htslib, update the env var `PACKAGE_VERSION`. To build an updated
 release of an existing version, update the env var `RELEASE_VERSION`. Also, make
@@ -20,3 +20,6 @@ under msys2).
 [TileDB-Inc/m2w64-htslib-feedstock]: https://github.com/TileDB-Inc/m2w64-htslib-feedstock
 [TileDB-Inc/tiledb-vcf-feedstock]: https://github.com/TileDB-Inc/tiledb-vcf-feedstock
 [TileDB-Inc/TileDB-VCF]: https://github.com/TileDB-Inc/TileDB-VCF
+
+[^explanation]: 'statically linked' here implies static linkage to all needed
+msys2 libraries that are not referencing .DLLs that are provided by Windows

--- a/patches/config.mk.staticlink.patch
+++ b/patches/config.mk.staticlink.patch
@@ -1,0 +1,43 @@
+46c46,56
+< LIBS     = -lregex -ldeflate -llzma -lbz2 -lws2_32 -lz 
+---
+> #LIBS     =  -lregex -ldeflate -llzma -lbz2 -lws2_32 -lz 
+> LIBS     =  $(MSYSTEM_PREFIX)/lib/libregex.a \
+>             $(MSYSTEM_PREFIX)/lib/libsystre.a \
+>             $(MSYSTEM_PREFIX)/lib/libtre.a \
+>             $(MSYSTEM_PREFIX)/lib/libintl.a \
+>             $(MSYSTEM_PREFIX)/lib/libiconv.a \
+>             $(MSYSTEM_PREFIX)/lib/libdeflate.a \
+>             $(MSYSTEM_PREFIX)/lib/liblzma.a \
+>             $(MSYSTEM_PREFIX)/lib/libbz2.a \
+>             $(MSYSTEM_PREFIX)/lib/libcrypt32.a \
+>             $(MSYSTEM_PREFIX)/lib/libwinpthread.a
+65c75
+< LIBCURL_LIBS = -lcurl
+---
+> LIBCURL_LIBS = $(MSYSTEM_PREFIX)/lib/libcurl.a
+83c93
+< CRYPTO_LIBS = -lcrypto
+---
+> CRYPTO_LIBS = $(MSYSTEM_PREFIX)/lib/libcrypto.a
+114a125,144
+> 
+> LIBS += \
+>      $(MSYSTEM_PREFIX)/lib/libssl.a \
+>      $(MSYSTEM_PREFIX)/lib/libwldap32.a \
+>      $(MSYSTEM_PREFIX)/lib/libcrypto.a \
+>      $(MSYSTEM_PREFIX)/lib/libcrypt32.a \
+>      $(MSYSTEM_PREFIX)/lib/libcertcli.a \
+>      $(MSYSTEM_PREFIX)/lib/libzstd.a \
+>      $(MSYSTEM_PREFIX)/lib/libbrotlidec.a \
+>      $(MSYSTEM_PREFIX)/lib/libbrotlienc.a \
+>      $(MSYSTEM_PREFIX)/lib/libbrotlicommon.a \
+>      $(MSYSTEM_PREFIX)/lib/libssh2.a \
+>      $(MSYSTEM_PREFIX)/lib/libidn2.a \
+>      $(MSYSTEM_PREFIX)/lib/libpsl.a \
+>      -lws2_32 \
+>      $(MSYSTEM_PREFIX)/lib/libunistring.a \
+>      $(MSYSTEM_PREFIX)/lib/libnghttp2.a \
+>      $(MSYSTEM_PREFIX)/lib/libz.a \
+>      $(MSYSTEM_PREFIX)/lib/libbcrypt.a \
+> 

--- a/patches/makefile.staticlink.patch
+++ b/patches/makefile.staticlink.patch
@@ -1,0 +1,52 @@
+574c574
+< 	$(CC) $(LDFLAGS) -o $@ test/test_bgzf.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/test_bgzf.o libhts.a  $(LIBS) -lpthread
+577c577
+< 	$(CC) $(LDFLAGS) -o $@ test/test_expr.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/test_expr.o libhts.a  $(LIBS) -lpthread
+580c580
+< 	$(CC) $(LDFLAGS) -o $@ test/test_kfunc.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/test_kfunc.o libhts.a  $(LIBS) -lpthread
+583c583
+< 	$(CC) $(LDFLAGS) -o $@ test/test_kstring.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/test_kstring.o libhts.a  $(LIBS) -lpthread
+613c613
+< 	$(CC) $(LDFLAGS) -o $@ test/test-bcf-sr.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/test-bcf-sr.o libhts.a  $(LIBS) -lpthread
+616c616
+< 	$(CC) $(LDFLAGS) -o $@ test/test-bcf-translate.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/test-bcf-translate.o libhts.a  $(LIBS) -lpthread
+698c698
+< 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads1.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads1.o libhts.a  $(LIBS) -lpthread
+701c701
+< 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads2.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads2.o libhts.a  $(LIBS) -lpthread
+704c704
+< 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads3.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads3.o libhts.a  $(LIBS) -lpthread
+707c707
+< 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads4.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads4.o libhts.a  $(LIBS) -lpthread
+710c710
+< 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads5.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads5.o libhts.a  $(LIBS) -lpthread
+713c713
+< 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads6.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads6.o libhts.a  $(LIBS) -lpthread
+716c716
+< 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads7.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads7.o libhts.a  $(LIBS) -lpthread

--- a/scripts/build-htslib.sh
+++ b/scripts/build-htslib.sh
@@ -1,0 +1,15 @@
+set -eu
+
+PATCH_DIR="$1"
+
+LIBHTS_SOVERSION=${LIBHTS_SOVERSION-3}
+
+./configure CFLAGS=-DCURL_STATICLIB
+
+# apply patches
+patch Makefile "${PATCH_DIR}/makefile.staticlink.patch"
+patch config.mk "${PATCH_DIR}/config.mk.staticlink.patch"
+
+make
+
+ls -lh hts-${LIBHTS_SOVERSION}.*

--- a/scripts/bundle-htslib.sh
+++ b/scripts/bundle-htslib.sh
@@ -1,0 +1,30 @@
+set -eu
+
+PACKAGE_VERSION=${PACKAGE_VERSION-1.15.1}
+LIBHTS_SOVERSION=${LIBHTS_SOVERSION-3}
+RELEASE_VERSION=${RELEASE_VERSION-0}
+
+FULL_VERSION=${PACKAGE_VERSION}-${RELEASE_VERSION}
+
+mkdir -p m2w64-htslib-${FULL_VERSION}/bin
+mkdir -p m2w64-htslib-${FULL_VERSION}/include/htslib
+mkdir -p m2w64-htslib-${FULL_VERSION}/lib
+
+cp LICENSE m2w64-htslib-${FULL_VERSION}
+cp hts-${LIBHTS_SOVERSION}.dll m2w64-htslib-${FULL_VERSION}/bin
+cp htslib/hts_defs.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/hts_endian.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/hts_expr.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/hts_log.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/hts.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/hts_os.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/vcf.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/vcfutils.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/hfile.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/kstring.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/k*.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/synced_bcf_reader.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp htslib/tbx.h m2w64-htslib-${FULL_VERSION}/include/htslib
+cp hts-${LIBHTS_SOVERSION}.lib m2w64-htslib-${FULL_VERSION}/lib
+
+tar -cvzf m2w64-htslib-${FULL_VERSION}.tar.gz -C m2w64-htslib-${FULL_VERSION} .

--- a/scripts/download-htslib.sh
+++ b/scripts/download-htslib.sh
@@ -1,0 +1,6 @@
+PACKAGE_VERSION=${PACKAGE_VERSION-1.16}
+
+curl -O -L "https://github.com/samtools/htslib/releases/download/${PACKAGE_VERSION}/htslib-${PACKAGE_VERSION}.tar.bz2"
+tar -jxvf htslib-${PACKAGE_VERSION}.tar.bz2
+mv htslib-${PACKAGE_VERSION}/* .
+rmdir htslib-${PACKAGE_VERSION}/

--- a/scripts/download-htslib.sh
+++ b/scripts/download-htslib.sh
@@ -1,4 +1,4 @@
-PACKAGE_VERSION=${PACKAGE_VERSION-1.16}
+PACKAGE_VERSION=${PACKAGE_VERSION-1.15.1}
 
 curl -O -L "https://github.com/samtools/htslib/releases/download/${PACKAGE_VERSION}/htslib-${PACKAGE_VERSION}.tar.bz2"
 tar -jxvf htslib-${PACKAGE_VERSION}.tar.bz2

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,0 +1,13 @@
+# https://github.com/samtools/htslib/blob/463830bf7de8c4ab731c4d67c49ddc446f498f50/INSTALL#L276
+# https://github.com/samtools/htslib/blob/develop/.appveyor.yml
+
+pacman -S --noconfirm --needed \
+  base-devel \
+  mingw-w64-x86_64-toolchain \
+  mingw-w64-x86_64-autotools \
+  mingw-w64-x86_64-zlib \
+  mingw-w64-x86_64-bzip2 \
+  mingw-w64-x86_64-xz \
+  mingw-w64-x86_64-curl \
+  mingw-w64-x86_64-tools-git \
+  mingw-w64-x86_64-libdeflate

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,26 @@
+set -eu
+
+# Create a release and upload tarball (but only if there is no existing release
+# for this version)
+
+if [[ -z "$GH_TOKEN" ]]
+then
+  echo "The env var GH_TOKEN is missing"
+  echo "Please define it as a GitHub PAT with write permissions to 'contents'"
+  exit 1
+fi
+
+PACKAGE_VERSION=${PACKAGE_VERSION-1.15.1}
+RELEASE_VERSION=${RELEASE_VERSION-0}
+FULL_VERSION=${PACKAGE_VERSION}-${RELEASE_VERSION}
+
+gh release list
+FULL_VERSION=${PACKAGE_VERSION}-${RELEASE_VERSION}
+if ! gh release list | grep -q "$FULL_VERSION"
+then
+  echo "Create new release $FULL_VERSION"
+  gh release create ${FULL_VERSION} \
+    --notes ${FULL_VERSION} \
+    --title ${FULL_VERSION} \
+    m2w64-htslib-${FULL_VERSION}.tar.gz
+fi


### PR DESCRIPTION
These scripts will build a statically-linked htslib under msys2 for version 1.15.1, create a GitHub release, and upload the release tarball as an asset. Thanks to @dhoke4tdb for the patches