### PR TITLE
Apply David's 2 patches to the htslib source code files

### DIFF
--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -14,7 +14,7 @@ on:
 env:
   PACKAGE_VERSION: 1.15.1
   LIBHTS_SOVERSION: 3
-  RELEASE_VERSION: 0 # equivalent to conda build number
+  RELEASE_VERSION: 1 # equivalent to conda build number
 jobs:
   build:
     name: build

--- a/patches/htslib/hts_defs.h.staticlink.patch
+++ b/patches/htslib/hts_defs.h.staticlink.patch
@@ -1,0 +1,17 @@
+diff --git a/htslib/hts_defs.h b/htslib/hts_defs.h
+index 7719215..39ff2e0 100644
+--- a/htslib/hts_defs.h
++++ b/htslib/hts_defs.h
+@@ -107,8 +107,12 @@ DEALINGS IN THE SOFTWARE.  */
+ #if defined(HTS_BUILDING_LIBRARY)
+ #define HTSLIB_EXPORT __declspec(dllexport)
+ #else
++#ifdef _MSC_VER
++#define HTSLIB_EXPORT __declspec(dllimport)
++#else
+ #define HTSLIB_EXPORT
+ #endif
++#endif
+ #elif HTS_COMPILER_HAS(__visibility__) || HTS_GCC_AT_LEAST(4,0)
+ #define HTSLIB_EXPORT __attribute__((__visibility__("default")))
+ #elif defined(__SUNPRO_C) && __SUNPRO_C >= 0x550

--- a/patches/htslib/vcf.h.staticlink.patch
+++ b/patches/htslib/vcf.h.staticlink.patch
@@ -1,0 +1,14 @@
+diff --git a/htslib/vcf.h b/htslib/vcf.h
+index 7a001ac..38d7f06 100644
+--- a/htslib/vcf.h
++++ b/htslib/vcf.h
+@@ -1341,7 +1341,9 @@ which works for both BCF and VCF.
+ #define BCF_MIN_BT_INT16 (-32760)      /* INT16_MIN + 8 */
+ #define BCF_MIN_BT_INT32 (-2147483640) /* INT32_MIN + 8 */
+ 
++HTSLIB_EXPORT
+ extern uint32_t bcf_float_vector_end;
++HTSLIB_EXPORT
+ extern uint32_t bcf_float_missing;
+ static inline void bcf_float_set(float *ptr, uint32_t value)
+ {

--- a/scripts/build-htslib.sh
+++ b/scripts/build-htslib.sh
@@ -9,6 +9,8 @@ LIBHTS_SOVERSION=${LIBHTS_SOVERSION-3}
 # apply patches
 patch Makefile "${PATCH_DIR}/makefile.staticlink.patch"
 patch config.mk "${PATCH_DIR}/config.mk.staticlink.patch"
+patch htslib/hts_defs.h "${PATCH_DIR}/htslib/hts_defs.h.staticlink.patch"
+patch htslib/vcf.h "${PATCH_DIR}/htslib/vcf.h.staticlink.patch"
 
 make
 


### PR DESCRIPTION
I applied the patches and confirmed that the tarball artifact created in my fork included the changes. I need at least one approval before I can push to main

https://github.com/jdblischak/m2w64-htslib-build/actions/runs/4176451902


```sh
$ grep -A 5 _MSC_VER include/htslib/hts_defs.h
#ifdef _MSC_VER
#define HTSLIB_EXPORT __declspec(dllimport)
#else
#define HTSLIB_EXPORT
#endif
#endif

$ grep -A 1 HTSLIB_EXPORT include/htslib/vcf.h | grep bcf_float_vector_end
extern uint32_t bcf_float_vector_end;

$ grep -A 1 HTSLIB_EXPORT include/htslib/vcf.h | grep bcf_float_missing
extern uint32_t bcf_float_missing;
```

