### PR TITLE
Build htslib 1.17

### DIFF
--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -12,7 +12,7 @@ on:
       - 'scripts/**'
   workflow_dispatch:
 env:
-  PACKAGE_VERSION: 1.16
+  PACKAGE_VERSION: 1.17
   LIBHTS_SOVERSION: 3
   RELEASE_VERSION: 0 # equivalent to conda build number
 jobs:

--- a/patches/makefile.staticlink.patch
+++ b/patches/makefile.staticlink.patch
@@ -1,52 +1,56 @@
-574c574
+632c632
 < 	$(CC) $(LDFLAGS) -o $@ test/test_bgzf.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/test_bgzf.o libhts.a  $(LIBS) -lpthread
-577c577
+635c635
 < 	$(CC) $(LDFLAGS) -o $@ test/test_expr.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/test_expr.o libhts.a  $(LIBS) -lpthread
-580c580
+638c638
+< 	$(CC) $(LDFLAGS) -o $@ test/test_faidx.o libhts.a -lz $(LIBS) -lpthread
+---
+> 	$(CC) $(LDFLAGS) -o $@ test/test_faidx.o libhts.a $(LIBS) -lpthread
+641c641
 < 	$(CC) $(LDFLAGS) -o $@ test/test_kfunc.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/test_kfunc.o libhts.a  $(LIBS) -lpthread
-583c583
+644c644
 < 	$(CC) $(LDFLAGS) -o $@ test/test_kstring.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/test_kstring.o libhts.a  $(LIBS) -lpthread
-613c613
+677c677
 < 	$(CC) $(LDFLAGS) -o $@ test/test-bcf-sr.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/test-bcf-sr.o libhts.a  $(LIBS) -lpthread
-616c616
+680c680
 < 	$(CC) $(LDFLAGS) -o $@ test/test-bcf-translate.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/test-bcf-translate.o libhts.a  $(LIBS) -lpthread
-698c698
+768c768
 < 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads1.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads1.o libhts.a  $(LIBS) -lpthread
-701c701
+771c771
 < 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads2.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads2.o libhts.a  $(LIBS) -lpthread
-704c704
+774c774
 < 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads3.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads3.o libhts.a  $(LIBS) -lpthread
-707c707
+777c777
 < 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads4.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads4.o libhts.a  $(LIBS) -lpthread
-710c710
+780c780
 < 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads5.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads5.o libhts.a  $(LIBS) -lpthread
-713c713
+783c783
 < 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads6.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads6.o libhts.a  $(LIBS) -lpthread
-716c716
+786c786
 < 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads7.o libhts.a -lz $(LIBS) -lpthread
 ---
 > 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads7.o libhts.a  $(LIBS) -lpthread


### PR DESCRIPTION
Closes #4 

I regenerated the Makefile patch to remove `-lz` in the new target `test/test_faidx` that was added in commit [8e43fb0](https://github.com/samtools/htslib/commit/8e43fb0650fabb8ca34775510e1e33ce6e48fc2a)