### PR TITLE
Build htslib 1.18

### DIFF
--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -12,7 +12,7 @@ on:
       - 'scripts/**'
   workflow_dispatch:
 env:
-  PACKAGE_VERSION: 1.17
+  PACKAGE_VERSION: 1.18
   LIBHTS_SOVERSION: 3
   RELEASE_VERSION: 0 # equivalent to conda build number
 jobs:


### PR DESCRIPTION
I'm building each htslib release one by one to limit the scope of any potential troubleshooting. I plan to only build a conda binary for the latest, 1.19, since that is what users will want to use anyways