### PR TITLE
Drop libcurl support

### DIFF
--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -14,7 +14,7 @@ on:
 env:
   PACKAGE_VERSION: 1.19
   LIBHTS_SOVERSION: 3
-  RELEASE_VERSION: 0 # equivalent to conda build number
+  RELEASE_VERSION: 1 # equivalent to conda build number
 jobs:
   build:
     name: build

--- a/patches/config.mk.staticlink.patch
+++ b/patches/config.mk.staticlink.patch
@@ -17,7 +17,7 @@
 ---
 > LIBCURL_LIBS = $(MSYSTEM_PREFIX)/lib/libcurl.a
 83c93
-< CRYPTO_LIBS = -lcrypto
+< CRYPTO_LIBS = 
 ---
 > CRYPTO_LIBS = $(MSYSTEM_PREFIX)/lib/libcrypto.a
 114a125,144

--- a/scripts/build-htslib.sh
+++ b/scripts/build-htslib.sh
@@ -1,4 +1,4 @@
-set -eu
+set -eux
 
 PATCH_DIR="$1"
 
@@ -8,7 +8,7 @@ LIBHTS_SOVERSION=${LIBHTS_SOVERSION-3}
 mv config.mk config.mk.libcurl
 ./configure --disable-libcurl
 cat config.mk
-diff config.mk config.mk.libcurl
+cat config.mk.libcurl
 
 # apply patches
 patch Makefile "${PATCH_DIR}/makefile.staticlink.patch"

--- a/scripts/build-htslib.sh
+++ b/scripts/build-htslib.sh
@@ -4,7 +4,11 @@ PATCH_DIR="$1"
 
 LIBHTS_SOVERSION=${LIBHTS_SOVERSION-3}
 
+./configure
+mv config.mk config.mk.libcurl
 ./configure --disable-libcurl
+cat config.mk
+diff config.mk config.mk.libcurl
 
 # apply patches
 patch Makefile "${PATCH_DIR}/makefile.staticlink.patch"

--- a/scripts/build-htslib.sh
+++ b/scripts/build-htslib.sh
@@ -1,14 +1,10 @@
-set -eux
+set -eu
 
 PATCH_DIR="$1"
 
 LIBHTS_SOVERSION=${LIBHTS_SOVERSION-3}
 
-./configure
-mv config.mk config.mk.libcurl
 ./configure --disable-libcurl
-cat config.mk
-cat config.mk.libcurl
 
 # apply patches
 patch Makefile "${PATCH_DIR}/makefile.staticlink.patch"

--- a/scripts/build-htslib.sh
+++ b/scripts/build-htslib.sh
@@ -4,7 +4,7 @@ PATCH_DIR="$1"
 
 LIBHTS_SOVERSION=${LIBHTS_SOVERSION-3}
 
-./configure CFLAGS=-DCURL_STATICLIB
+./configure --disable-libcurl
 
 # apply patches
 patch Makefile "${PATCH_DIR}/makefile.staticlink.patch"

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,14 +1,7 @@
 # https://github.com/samtools/htslib/blob/463830bf7de8c4ab731c4d67c49ddc446f498f50/INSTALL#L276
 # https://github.com/samtools/htslib/blob/develop/.appveyor.yml
 
-# Downgrade curl to version that can be statically linked
-# https://github.com/msys2/MINGW-packages/issues/21028
-# https://github.com/LizardByte/Sunshine/issues/2722#issuecomment-2177325777
-wget https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst
-pacman -U --noconfirm mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst
-
 pacman -S --noconfirm --needed \
-  --ignore=mingw-w64-ucrt-x86_64-curl \
   base-devel \
   mingw-w64-x86_64-toolchain \
   mingw-w64-x86_64-autotools \
@@ -20,4 +13,3 @@ pacman -S --noconfirm --needed \
   mingw-w64-x86_64-libdeflate
 
 pacman -Q
-pacman -Ss curl

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -11,3 +11,9 @@ pacman -S --noconfirm --needed \
   mingw-w64-x86_64-curl \
   mingw-w64-x86_64-tools-git \
   mingw-w64-x86_64-libdeflate
+
+# Downgrade curl to version that can be statically linked
+# https://github.com/msys2/MINGW-packages/issues/21028
+# https://github.com/LizardByte/Sunshine/issues/2722#issuecomment-2177325777
+wget https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst
+pacman -U --noconfirm mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,7 +1,14 @@
 # https://github.com/samtools/htslib/blob/463830bf7de8c4ab731c4d67c49ddc446f498f50/INSTALL#L276
 # https://github.com/samtools/htslib/blob/develop/.appveyor.yml
 
+# Downgrade curl to version that can be statically linked
+# https://github.com/msys2/MINGW-packages/issues/21028
+# https://github.com/LizardByte/Sunshine/issues/2722#issuecomment-2177325777
+wget https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst
+pacman -U --noconfirm mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst
+
 pacman -S --noconfirm --needed \
+  --ignore=mingw-w64-ucrt-x86_64-curl \
   base-devel \
   mingw-w64-x86_64-toolchain \
   mingw-w64-x86_64-autotools \
@@ -11,9 +18,3 @@ pacman -S --noconfirm --needed \
   mingw-w64-x86_64-curl \
   mingw-w64-x86_64-tools-git \
   mingw-w64-x86_64-libdeflate
-
-# Downgrade curl to version that can be statically linked
-# https://github.com/msys2/MINGW-packages/issues/21028
-# https://github.com/LizardByte/Sunshine/issues/2722#issuecomment-2177325777
-wget https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst
-pacman -U --noconfirm mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -18,3 +18,6 @@ pacman -S --noconfirm --needed \
   mingw-w64-x86_64-curl \
   mingw-w64-x86_64-tools-git \
   mingw-w64-x86_64-libdeflate
+
+pacman -Q
+pacman -Ss curl


### PR DESCRIPTION
**summary:** Recent releases of libcurl broke our static build of htslib. I installed an older release of libcurl, but this didn't fix the problem. Instead of continuing to troubleshoot, we decided to disable libcurl support for this Windows version of htslib (thus disabling S3 support for bcftools and any other tools that rely on htslib for this feature).

Attempting to install a previous version of curl that can be statically linked

xref: #8, #9, https://github.com/msys2/MINGW-packages/issues/21028, https://github.com/LizardByte/Sunshine/issues/2722#issuecomment-2177325777