### PR TITLE
Improve robustness of the GitHub Actions workflow.

### DIFF
--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -1,6 +1,8 @@
 name: Build a statically linked htslib.dll under msys2
 on:
   push:
+    branches:
+      - main
     paths:
       - '.github/workflows/msys2-htslib-build.yml'
       - 'patches/**'

--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -72,4 +72,5 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
+          GIT_REF: ${{ github.ref }}
         run: bash scripts/release.sh

--- a/.github/workflows/msys2-htslib-build.yml
+++ b/.github/workflows/msys2-htslib-build.yml
@@ -58,7 +58,7 @@ jobs:
   release:
     name: release
     needs: build
-    if: github.repository == 'TileDB-Inc/m2w64-htslib-build' &&  github.event_name != 'pull_request'
+    if: github.repository_owner == 'TileDB-Inc' &&  github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,6 +10,13 @@ then
   exit 1
 fi
 
+if [[ -z "$GIT_REF" ]]
+then
+  echo "The env var GIT_REF is missing"
+  echo "Please define it as the reference to the commit to make the release on"
+  exit 1
+fi
+
 PACKAGE_VERSION=${PACKAGE_VERSION-1.15.1}
 RELEASE_VERSION=${RELEASE_VERSION-0}
 FULL_VERSION=${PACKAGE_VERSION}-${RELEASE_VERSION}
@@ -22,5 +29,6 @@ then
   gh release create ${FULL_VERSION} \
     --notes ${FULL_VERSION} \
     --title ${FULL_VERSION} \
+    --target ${GIT_REF} \
     m2w64-htslib-${FULL_VERSION}.tar.gz
 fi


### PR DESCRIPTION
* Its `on: push` event activates only on the `main` branch.
* The `release` job does not run `on: workflow_dispatch`.
* The release script explicitly specifies the commit to tag. Won't change behavior at present, but will be good for future-proofing.